### PR TITLE
Support of sources import was added

### DIFF
--- a/src/CodeReview.Orchestrator/Activities/ActivityFactory.cs
+++ b/src/CodeReview.Orchestrator/Activities/ActivityFactory.cs
@@ -41,8 +41,13 @@ namespace GodelTech.CodeReview.Orchestrator.Activities
                     _containerService,
                     _archiveService,
                     _directoryService,
-                    _pathService,
                     _loggerFactory.CreateLogger<ImportDataActivity>()),
+                new ImportSourcesActivity(
+                    manifest.Sources,
+                    _containerService,
+                    _archiveService,
+                    _directoryService,
+                    _loggerFactory.CreateLogger<ImportSourcesActivity>()),
                 new RunProcessorsActivity(
                     manifest.Activities, 
                     _activityExecutor,

--- a/src/CodeReview.Orchestrator/Activities/ImportDataActivity.cs
+++ b/src/CodeReview.Orchestrator/Activities/ImportDataActivity.cs
@@ -7,15 +7,12 @@ using Microsoft.Extensions.Logging;
 
 namespace GodelTech.CodeReview.Orchestrator.Activities
 {
-    public class ImportDataActivity : IActivity
+    public class ImportDataActivity : ImportFolderActivity
     {
-        private const string ImportsFolderPath = "/imports";
-        
+        protected override string ContainerFolderPath => "/imports";
+        protected override string HostFolderPath => _settings.FolderPath;
+
         private readonly ImportedDataSettings _settings;
-        private readonly IContainerService _containerService;
-        private readonly ITarArchiveService _tarArchiveService;
-        private readonly IDirectoryService _directoryService;
-        private readonly ILogger<ImportDataActivity> _logger;
 
         public ImportDataActivity(
             ImportedDataSettings importedDataSettings,
@@ -23,54 +20,9 @@ namespace GodelTech.CodeReview.Orchestrator.Activities
             ITarArchiveService tarArchiveService,
             IDirectoryService directoryService,
             ILogger<ImportDataActivity> logger)
+            : base(containerService, tarArchiveService, directoryService, logger)
         {
             _settings = importedDataSettings ?? throw new ArgumentNullException(nameof(importedDataSettings));
-            _containerService = containerService ?? throw new ArgumentNullException(nameof(containerService));
-            _tarArchiveService = tarArchiveService ?? throw new ArgumentNullException(nameof(tarArchiveService));
-            _directoryService = directoryService ?? throw new ArgumentNullException(nameof(directoryService));
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        }
-        
-        public async Task<bool> ExecuteAsync(IProcessingContext context)
-        {
-            if (context == null) 
-                throw new ArgumentNullException(nameof(context));
-
-            var folderPath = context.ResolvePath(_settings.FolderPath);
-            
-            if (!_directoryService.Exists(folderPath))
-            {
-                _logger.LogInformation("No imports folder found. Import is not performed. Folder = {folderPath}", folderPath);
-                return true;
-            }
-
-            _logger.LogInformation("Starting data import...");
-
-            var containerId = await _containerService.CreateContainerAsync(
-                Constants.WorkerImage,
-                Array.Empty<string>(),
-                ImmutableDictionary<string, string>.Empty,
-                new MountedVolume
-                {
-                    IsBindMount = false,
-                    Source = context.ImportsVolumeId,
-                    Target = ImportsFolderPath
-                });
-
-            try
-            {
-                await using var outStream = _tarArchiveService.Create(folderPath);
-
-                await _containerService.ImportFilesIntoContainerAsync(containerId, ImportsFolderPath, outStream);
-
-                _logger.LogInformation("Data import completed.");
-            }
-            finally
-            {
-                await _containerService.RemoveContainerAsync(containerId);
-            }
-
-            return true;
         }
     }
 }

--- a/src/CodeReview.Orchestrator/Activities/ImportDataActivity.cs
+++ b/src/CodeReview.Orchestrator/Activities/ImportDataActivity.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Immutable;
-using System.Threading.Tasks;
 using GodelTech.CodeReview.Orchestrator.Model;
 using GodelTech.CodeReview.Orchestrator.Services;
 using Microsoft.Extensions.Logging;
@@ -19,10 +17,12 @@ namespace GodelTech.CodeReview.Orchestrator.Activities
             IContainerService containerService,
             ITarArchiveService tarArchiveService,
             IDirectoryService directoryService,
-            ILogger<ImportDataActivity> logger)
+            ILogger logger)
             : base(containerService, tarArchiveService, directoryService, logger)
         {
             _settings = importedDataSettings ?? throw new ArgumentNullException(nameof(importedDataSettings));
         }
+        
+        protected override string GetVolumeToMount(IProcessingContext context) => context.ImportsVolumeId;
     }
 }

--- a/src/CodeReview.Orchestrator/Activities/ImportFolderActivity.cs
+++ b/src/CodeReview.Orchestrator/Activities/ImportFolderActivity.cs
@@ -51,7 +51,7 @@ namespace GodelTech.CodeReview.Orchestrator.Activities
                 new MountedVolume
                 {
                     IsBindMount = false,
-                    Source = context.SourceCodeVolumeId,
+                    Source = GetVolumeToMount(context),
                     Target = ContainerFolderPath
                 });
 
@@ -70,5 +70,7 @@ namespace GodelTech.CodeReview.Orchestrator.Activities
 
             return true;
         }
+
+        protected abstract string GetVolumeToMount(IProcessingContext context);
     }
 }

--- a/src/CodeReview.Orchestrator/Activities/ImportFolderActivity.cs
+++ b/src/CodeReview.Orchestrator/Activities/ImportFolderActivity.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using GodelTech.CodeReview.Orchestrator.Model;
+using GodelTech.CodeReview.Orchestrator.Services;
+using Microsoft.Extensions.Logging;
+
+namespace GodelTech.CodeReview.Orchestrator.Activities
+{
+    public abstract class ImportFolderActivity : IActivity
+    {
+        private readonly IContainerService _containerService;
+        private readonly ITarArchiveService _tarArchiveService;
+        private readonly IDirectoryService _directoryService;
+        private readonly ILogger _logger;
+
+        protected abstract string ContainerFolderPath { get; }
+        protected abstract string HostFolderPath { get; }
+
+        protected ImportFolderActivity(
+            IContainerService containerService,
+            ITarArchiveService tarArchiveService,
+            IDirectoryService directoryService,
+            ILogger logger)
+        {
+            _containerService = containerService ?? throw new ArgumentNullException(nameof(containerService));
+            _tarArchiveService = tarArchiveService ?? throw new ArgumentNullException(nameof(tarArchiveService));
+            _directoryService = directoryService ?? throw new ArgumentNullException(nameof(directoryService));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+        
+        public async Task<bool> ExecuteAsync(IProcessingContext context)
+        {
+            if (context == null) 
+                throw new ArgumentNullException(nameof(context));
+
+            var folderPath = context.ResolvePath(HostFolderPath);
+            
+            if (!_directoryService.Exists(folderPath))
+            {
+                _logger.LogInformation("No sources folder not found. Import is not performed. Folder = {folderPath}", folderPath);
+                return true;
+            }
+
+            _logger.LogInformation("Starting sources import...");
+
+            var containerId = await _containerService.CreateContainerAsync(
+                Constants.WorkerImage,
+                Array.Empty<string>(),
+                ImmutableDictionary<string, string>.Empty,
+                new MountedVolume
+                {
+                    IsBindMount = false,
+                    Source = context.SourceCodeVolumeId,
+                    Target = ContainerFolderPath
+                });
+
+            try
+            {
+                await using var outStream = _tarArchiveService.Create(folderPath);
+
+                await _containerService.ImportFilesIntoContainerAsync(containerId, ContainerFolderPath, outStream);
+
+                _logger.LogInformation("Sources import completed.");
+            }
+            finally
+            {
+                await _containerService.RemoveContainerAsync(containerId);
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/CodeReview.Orchestrator/Activities/ImportSourcesActivity.cs
+++ b/src/CodeReview.Orchestrator/Activities/ImportSourcesActivity.cs
@@ -17,10 +17,12 @@ namespace GodelTech.CodeReview.Orchestrator.Activities
             IContainerService containerService,
             ITarArchiveService tarArchiveService,
             IDirectoryService directoryService,
-            ILogger<ImportSourcesActivity> logger)
+            ILogger logger)
             : base(containerService, tarArchiveService, directoryService, logger)
         {
             _settings = settings ?? throw new ArgumentNullException(nameof(settings));
         }
+        
+        protected override string GetVolumeToMount(IProcessingContext context) => context.SourceCodeVolumeId;
     }
 }

--- a/src/CodeReview.Orchestrator/Activities/ImportSourcesActivity.cs
+++ b/src/CodeReview.Orchestrator/Activities/ImportSourcesActivity.cs
@@ -1,21 +1,16 @@
 using System;
-using System.Collections.Immutable;
-using System.Threading.Tasks;
 using GodelTech.CodeReview.Orchestrator.Model;
 using GodelTech.CodeReview.Orchestrator.Services;
 using Microsoft.Extensions.Logging;
 
 namespace GodelTech.CodeReview.Orchestrator.Activities
 {
-    public class ImportSourcesActivity : IActivity
+    public class ImportSourcesActivity : ImportFolderActivity
     {
-        private const string SourcesFolderPath = "/src";
-        
         private readonly SourcesDataSettings _settings;
-        private readonly IContainerService _containerService;
-        private readonly ITarArchiveService _tarArchiveService;
-        private readonly IDirectoryService _directoryService;
-        private readonly ILogger<ImportSourcesActivity> _logger;
+        
+        protected override string ContainerFolderPath => "/src";
+        protected override string HostFolderPath => _settings.FolderPath;
 
         public ImportSourcesActivity(
             SourcesDataSettings settings,
@@ -23,54 +18,9 @@ namespace GodelTech.CodeReview.Orchestrator.Activities
             ITarArchiveService tarArchiveService,
             IDirectoryService directoryService,
             ILogger<ImportSourcesActivity> logger)
+            : base(containerService, tarArchiveService, directoryService, logger)
         {
             _settings = settings ?? throw new ArgumentNullException(nameof(settings));
-            _containerService = containerService ?? throw new ArgumentNullException(nameof(containerService));
-            _tarArchiveService = tarArchiveService ?? throw new ArgumentNullException(nameof(tarArchiveService));
-            _directoryService = directoryService ?? throw new ArgumentNullException(nameof(directoryService));
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        }
-        
-        public async Task<bool> ExecuteAsync(IProcessingContext context)
-        {
-            if (context == null) 
-                throw new ArgumentNullException(nameof(context));
-
-            var folderPath = context.ResolvePath(_settings.FolderPath);
-            
-            if (!_directoryService.Exists(folderPath))
-            {
-                _logger.LogInformation("No sources folder not found. Import is not performed. Folder = {folderPath}", folderPath);
-                return true;
-            }
-
-            _logger.LogInformation("Starting sources import...");
-
-            var containerId = await _containerService.CreateContainerAsync(
-                Constants.WorkerImage,
-                Array.Empty<string>(),
-                ImmutableDictionary<string, string>.Empty,
-                new MountedVolume
-                {
-                    IsBindMount = false,
-                    Source = context.SourceCodeVolumeId,
-                    Target = SourcesFolderPath
-                });
-
-            try
-            {
-                await using var outStream = _tarArchiveService.Create(folderPath);
-
-                await _containerService.ImportFilesIntoContainerAsync(containerId, SourcesFolderPath, outStream);
-
-                _logger.LogInformation("Sources import completed.");
-            }
-            finally
-            {
-                await _containerService.RemoveContainerAsync(containerId);
-            }
-
-            return true;
         }
     }
 }

--- a/src/CodeReview.Orchestrator/CodeReview.Orchestrator.csproj
+++ b/src/CodeReview.Orchestrator/CodeReview.Orchestrator.csproj
@@ -13,7 +13,7 @@
     <Company>Godel Technologies Europe</Company>
     <Authors>Andrei Salanoi</Authors>
     <RepositoryUrl>https://github.com/GodelTech/CodeReview.Orchestrator</RepositoryUrl>
-    <VersionPrefix>0.0.4</VersionPrefix>
+    <VersionPrefix>0.1.0</VersionPrefix>
     <PackageIconUrl>https://www.gravatar.com/avatar/839234621070de51e7b9cabd5ceee8fe?s=64</PackageIconUrl>
 
     <!-- SonarQube needs this -->

--- a/src/CodeReview.Orchestrator/Commands/CreateNewManifestCommand.cs
+++ b/src/CodeReview.Orchestrator/Commands/CreateNewManifestCommand.cs
@@ -28,6 +28,11 @@ namespace GodelTech.CodeReview.Orchestrator.Commands
                     FolderPath = "./imports"
                 },
                 
+                Sources = new ()
+                {
+                    FolderPath = "./src"
+                },
+                
                 Artifacts = new ()
                 {
                     FolderPath = "./artifacts",

--- a/src/CodeReview.Orchestrator/Model/AnalysisManifest.cs
+++ b/src/CodeReview.Orchestrator/Model/AnalysisManifest.cs
@@ -8,6 +8,9 @@ namespace GodelTech.CodeReview.Orchestrator.Model
         [Required]
         public ImportedDataSettings Imports { get; set; } = new();
 
+        [Required]
+        public SourcesDataSettings Sources { get; set; } = new();
+
         [Required] 
         public ArtifactsSettings Artifacts { get; set; } = new();
 

--- a/src/CodeReview.Orchestrator/Model/SourcesDataSettings.cs
+++ b/src/CodeReview.Orchestrator/Model/SourcesDataSettings.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace GodelTech.CodeReview.Orchestrator.Model
+{
+    public class SourcesDataSettings
+    {
+        [Required]
+        [MaxLength(Constants.MaxPathLength)]
+        public string FolderPath { get; set; } = "./src";
+    }
+}

--- a/src/CodeReview.Orchestrator/Services/ManifestExpressionExpander.cs
+++ b/src/CodeReview.Orchestrator/Services/ManifestExpressionExpander.cs
@@ -23,8 +23,8 @@ namespace GodelTech.CodeReview.Orchestrator.Services
 
             _variableExpressionProvider.SetVariables(manifest.Variables);
 
+            manifest.Sources.FolderPath = _expressionEvaluator.Evaluate(manifest.Sources.FolderPath);
             manifest.Artifacts.FolderPath = _expressionEvaluator.Evaluate(manifest.Artifacts.FolderPath);
-
             manifest.Imports.FolderPath = _expressionEvaluator.Evaluate(manifest.Imports.FolderPath);
             
             manifest.Variables = manifest.Variables.ToDictionary(x => x.Key, x => _expressionEvaluator.Evaluate(x.Value), StringComparer.OrdinalIgnoreCase);


### PR DESCRIPTION
#### CHANGE TYPE
<!--- MANDATORY: Delete the items that don't apply -->
 - [x] Minor

#### IMPACT, DEPENDENCIES AND TEST CONSIDERATIONS
Manifest allows user to import source code into `sources` volume instead of using source code provider. If folder doesn't exists no sources import is performed.