### PR TITLE
extract-metadata-empty-path: add check on string.Empty

### DIFF
--- a/test/CodeReview.Orchestrator.SubsystemTests/StartUpFixture.cs
+++ b/test/CodeReview.Orchestrator.SubsystemTests/StartUpFixture.cs
@@ -15,6 +15,8 @@ namespace CodeReview.Orchestrator.SubsystemTests
             Config.Assembly = typeof(TestBase).Assembly;
             Config.ResourcePath = "CodeReview.Orchestrator.SubsystemTests.Resources";
             GodelTech.StoryLine.Wiremock.Config.SetBaseAddress(configuration["WiremockAddress"]);
+
+            Directory.CreateDirectory(Config.OutputDirectoryPath);
         }
 
         public void Dispose()

--- a/test/CodeReview.Orchestrator.SubsystemTests/TestBase.cs
+++ b/test/CodeReview.Orchestrator.SubsystemTests/TestBase.cs
@@ -1,19 +1,9 @@
-﻿using System;
-using Xunit;
+﻿using Xunit;
 
 namespace CodeReview.Orchestrator.SubsystemTests
 {
     [Collection(nameof(StartUpFixture))]
-    public class TestBase : IDisposable
+    public class TestBase
     {
-        protected TestBase()
-        {
-            GodelTech.StoryLine.Wiremock.Config.ResetAll();
-        }
-
-        public void Dispose()
-        {
-            GodelTech.StoryLine.Wiremock.Config.ResetAll();
-        }
     }
 }

--- a/test/CodeReview.Orchestrator.SubsystemTests/Tests/ExtractMetadataTests.cs
+++ b/test/CodeReview.Orchestrator.SubsystemTests/Tests/ExtractMetadataTests.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using CodeReview.Orchestrator.SubsystemTests.Actions;
 using CodeReview.Orchestrator.SubsystemTests.Expectations;
 using CodeReview.Orchestrator.SubsystemTests.Utils;
@@ -37,6 +38,24 @@ namespace CodeReview.Orchestrator.SubsystemTests.Tests
                 .Performs<ExecuteProcess>(proc => proc
                     .WithCommandArg("extract-metadata")
                     .WithCommandArg(outputArg, outputArgValue))
+                .Then()
+                .Expects<ProcessResult>(proc => proc
+                    .ExitCode(Constants.ExitCode.Error))
+                .Run();
+        }
+        
+        [Theory]
+        [InlineData("-o")]
+        [InlineData("--output")]
+        public void When_Output_Path_Does_Not_Exist_Should_Return_Error(string outputArg)
+        {
+            var outputPath = Path.Combine("tmp", MetadataName);
+            
+            Scenario.New()
+                .When()
+                .Performs<ExecuteProcess>(proc => proc
+                    .WithCommandArg("extract-metadata")
+                    .WithCommandArg(outputArg, outputPath))
                 .Then()
                 .Expects<ProcessResult>(proc => proc
                     .ExitCode(Constants.ExitCode.Error))

--- a/test/CodeReview.Orchestrator.SubsystemTests/Tests/RunTests.cs
+++ b/test/CodeReview.Orchestrator.SubsystemTests/Tests/RunTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace CodeReview.Orchestrator.SubsystemTests.Tests
 {
-    public class RunTests : TestBase
+    public class RunTests : WiremockTestBase
     {
         private const string AlpineImage = "alpine";
         private const string GitProviderImage = "godeltech/codereview.tools.gitprovider";

--- a/test/CodeReview.Orchestrator.SubsystemTests/WiremockTestBase.cs
+++ b/test/CodeReview.Orchestrator.SubsystemTests/WiremockTestBase.cs
@@ -1,0 +1,19 @@
+using System;
+using Xunit;
+
+namespace CodeReview.Orchestrator.SubsystemTests
+{
+    [Collection(nameof(StartUpFixture))]
+    public class WiremockTestBase : TestBase, IDisposable
+    {
+        protected WiremockTestBase()
+        {
+            GodelTech.StoryLine.Wiremock.Config.ResetAll();
+        }
+
+        public void Dispose()
+        {
+            GodelTech.StoryLine.Wiremock.Config.ResetAll();
+        }
+    }
+}


### PR DESCRIPTION
#### CHANGE TYPE
<!--- MANDATORY: Delete the items that don't apply -->
 - [ ] Major
 - [ ] Minor
 - [x] Patch

#### GITHUB ISSUE LINK
None

#### Error description
```
dotnet CodeReview.Orchestrator.dll extract-metadata -o test.json
Unhandled exception. System.ArgumentException: Path cannot be the empty string or all whitespace. (Parameter 'path')
```

#### IMPACT, DEPENDENCIES AND TEST CONSIDERATIONS
extract-metadata command. 