### PR TITLE
Update Docker.DotNet package

### DIFF
--- a/src/CodeReview.Orchestrator/CodeReview.Orchestrator.csproj
+++ b/src/CodeReview.Orchestrator/CodeReview.Orchestrator.csproj
@@ -27,7 +27,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="Docker.DotNet" Version="3.125.5" />
+    <PackageReference Include="Docker.DotNet" Version="3.125.12" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
     <PackageReference Include="SharpCompress" Version="0.28.1" />


### PR DESCRIPTION
#### CHANGE TYPE
<!--- MANDATORY: Delete the items that don't apply -->
 - [ ] Major
 - [ ] Minor
 - [x] Patch

#### GITHUB ISSUE LINK


#### IMPACT, DEPENDENCIES AND TEST CONSIDERATIONS
When the orchestrator tried to start a container it failed with `cannot hijack chunked or content length stream` error. Updating Docker.DotNet package fixes that issue.