### PR TITLE
fixed an issue where the orchestrator was unable to import a huge directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -404,3 +404,6 @@ ASALocalRun/
 
 # docker
 *.env
+
+# Rider IDE
+.idea/

--- a/src/CodeReview.Orchestrator/CodeReview.Orchestrator.csproj
+++ b/src/CodeReview.Orchestrator/CodeReview.Orchestrator.csproj
@@ -26,7 +26,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ByteSize" Version="2.1.1" />
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="Docker.DotNet" Version="3.125.12" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />

--- a/src/CodeReview.Orchestrator/CodeReview.Orchestrator.csproj
+++ b/src/CodeReview.Orchestrator/CodeReview.Orchestrator.csproj
@@ -26,6 +26,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="ByteSize" Version="2.1.1" />
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="Docker.DotNet" Version="3.125.12" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />

--- a/src/CodeReview.Orchestrator/Program.cs
+++ b/src/CodeReview.Orchestrator/Program.cs
@@ -99,6 +99,7 @@ namespace GodelTech.CodeReview.Orchestrator
             serviceProvider.AddSingleton<IDockerEngineContext, DockerEngineContext>();
             serviceProvider.AddSingleton<IVariableExpressionProvider, VariableExpressionProvider>();
             serviceProvider.AddSingleton<IGuidFactory, GuidFactory>();
+            serviceProvider.AddSingleton<ITempFileFactory, TempFileFactory>();
 
             serviceProvider.AddTransient<ITempFolderFactory, TempFolderFactory>();
             serviceProvider.AddTransient<IDockerContextSwitcher, DockerContextSwitcher>();

--- a/src/CodeReview.Orchestrator/Services/ContainerService.cs
+++ b/src/CodeReview.Orchestrator/Services/ContainerService.cs
@@ -157,7 +157,7 @@ namespace GodelTech.CodeReview.Orchestrator.Services
                 throw new ArgumentException("Value cannot be null or whitespace.", nameof(containerPath));
 
             using var client = _dockerClientFactory.Create();
-            
+
             await client.Containers.ExtractArchiveToContainerAsync(
                 containerId,
                 new ContainerPathStatParameters

--- a/src/CodeReview.Orchestrator/Services/DirectoryService.cs
+++ b/src/CodeReview.Orchestrator/Services/DirectoryService.cs
@@ -1,7 +1,6 @@
-﻿using System.ComponentModel;
-using System.IO;
+﻿using System.IO;
 using System.Linq;
-using ByteSizeLib;
+using GodelTech.CodeReview.Orchestrator.Utils;
 
 namespace GodelTech.CodeReview.Orchestrator.Services
 {
@@ -12,7 +11,7 @@ namespace GodelTech.CodeReview.Orchestrator.Services
             return Directory.Exists(path);
         }
 
-        public ByteSize DirectorySize(string path)
+        public ByteSize GetDirectorySize(string path)
         {
             var bytes = Directory.EnumerateFiles(path, "*", SearchOption.AllDirectories)
                 .Select(p => new FileInfo(p))

--- a/src/CodeReview.Orchestrator/Services/DirectoryService.cs
+++ b/src/CodeReview.Orchestrator/Services/DirectoryService.cs
@@ -1,4 +1,7 @@
-﻿using System.IO;
+﻿using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using ByteSizeLib;
 
 namespace GodelTech.CodeReview.Orchestrator.Services
 {
@@ -7,6 +10,15 @@ namespace GodelTech.CodeReview.Orchestrator.Services
         public bool Exists(string path)
         {
             return Directory.Exists(path);
+        }
+
+        public ByteSize DirectorySize(string path)
+        {
+            var bytes = Directory.EnumerateFiles(path, "*", SearchOption.AllDirectories)
+                .Select(p => new FileInfo(p))
+                .Sum(fileInfo => fileInfo.Length);
+
+            return ByteSize.FromBytes(bytes);
         }
 
         public DirectoryInfo CreateDirectory(string path)

--- a/src/CodeReview.Orchestrator/Services/DockerVolumeImporter.cs
+++ b/src/CodeReview.Orchestrator/Services/DockerVolumeImporter.cs
@@ -1,25 +1,31 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using ByteSizeLib;
 using GodelTech.CodeReview.Orchestrator.Activities;
 using GodelTech.CodeReview.Orchestrator.Model;
+using GodelTech.CodeReview.Orchestrator.Utils;
 
 namespace GodelTech.CodeReview.Orchestrator.Services
 {
     public class DockerVolumeImporter : IDockerVolumeImporter
     {
+        private readonly ITempFileFactory _tempFileFactory;
         private readonly IContainerService _containerService;
         private readonly IDirectoryService _directoryService;
         private readonly ITarArchiveService _tarArchiveService;
         private readonly IDockerEngineContext _dockerEngineContext;
 
         public DockerVolumeImporter(
+            ITempFileFactory tempFileFactory,
             IContainerService containerService, 
             IDirectoryService directoryService, 
             ITarArchiveService tarArchiveService, 
             IDockerEngineContext dockerEngineContext)
         {
+            _tempFileFactory = tempFileFactory ?? throw new ArgumentNullException(nameof(tempFileFactory));
             _containerService = containerService ?? throw new ArgumentNullException(nameof(containerService));
             _directoryService = directoryService ?? throw new ArgumentNullException(nameof(directoryService));
             _tarArchiveService = tarArchiveService ?? throw new ArgumentNullException(nameof(tarArchiveService));
@@ -39,7 +45,10 @@ namespace GodelTech.CodeReview.Orchestrator.Services
                     if (!_directoryService.Exists(folderPath))
                         continue;
 
-                    await using var outStream = _tarArchiveService.Create(folderPath);
+                    Stream outStream;
+                    using var _ = _directoryService.DirectorySize(folderPath) <= ByteSize.FromMegaBytes(300)
+                        ? CreateArchiveInMemory(folderPath, out outStream)
+                        : CreateArchiveInFileSystem(folderPath, out outStream);
 
                     await _containerService.ImportFilesIntoContainerAsync(containerId, volume.TargetFolder, outStream);
                 }
@@ -49,7 +58,29 @@ namespace GodelTech.CodeReview.Orchestrator.Services
                 await _containerService.RemoveContainerAsync(containerId);
             }
         }
-        
+
+        private IDisposable CreateArchiveInMemory(string path, out Stream stream)
+        {
+            stream = _tarArchiveService.CreateInMemory(path);
+
+            return Disposable.CreateDisposableAction(stream, static toDispose =>
+            {
+                toDispose.Dispose();
+            });
+        }
+
+        private IDisposable CreateArchiveInFileSystem(string path, out Stream stream)
+        {
+            var tmpFile = _tempFileFactory.Create();
+            stream = _tarArchiveService.CreateInFile(path, tmpFile.Path);
+
+            return Disposable.CreateDisposableAction((stream, tmpFile), static toDispose =>
+            {
+                toDispose.stream.Dispose();
+                toDispose.tmpFile.Dispose();
+            });
+        }
+
         private async Task<string> CreateWorkerContainerAsync(IProcessingContext context, ICollection<Volume> volumes)
         {
             var mountedVolumes = ResolveMountedVolumes(context, volumes).ToArray();

--- a/src/CodeReview.Orchestrator/Services/FileService.cs
+++ b/src/CodeReview.Orchestrator/Services/FileService.cs
@@ -6,6 +6,32 @@ namespace GodelTech.CodeReview.Orchestrator.Services
 {
     public class FileService : IFileService
     {
+        public void Delete(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+                throw new ArgumentException("Value cannot be null or whitespace.", nameof(path));
+
+            File.Delete(path);
+        }
+
+        public Stream Open(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+                throw new ArgumentException("Value cannot be null or whitespace.", nameof(path));
+
+            return File.Open(path, FileMode.Open);
+        }
+
+        public void Move(string sourceFileName, string destFileName)
+        {
+            if (string.IsNullOrWhiteSpace(sourceFileName))
+                throw new ArgumentException("Value cannot be null or whitespace.", nameof(sourceFileName));
+            if (string.IsNullOrWhiteSpace(destFileName))
+                throw new ArgumentException("Value cannot be null or whitespace.", nameof(destFileName));
+            
+            File.Move(sourceFileName, destFileName);
+        }
+
         public Task<string> ReadAllTextAsync(string path)
         {
             if (string.IsNullOrWhiteSpace(path))

--- a/src/CodeReview.Orchestrator/Services/IDirectoryService.cs
+++ b/src/CodeReview.Orchestrator/Services/IDirectoryService.cs
@@ -1,11 +1,11 @@
 ﻿using System.IO;
-using ByteSizeLib;
+using GodelTech.CodeReview.Orchestrator.Utils;
 
 namespace GodelTech.CodeReview.Orchestrator.Services
 {
     public interface IDirectoryService
     {
-        ByteSize DirectorySize(string path);
+        ByteSize GetDirectorySize(string path);
         bool Exists(string path);
         DirectoryInfo CreateDirectory(string path);
         void Delete(string path, bool recursive);

--- a/src/CodeReview.Orchestrator/Services/IDirectoryService.cs
+++ b/src/CodeReview.Orchestrator/Services/IDirectoryService.cs
@@ -1,9 +1,11 @@
 ﻿using System.IO;
+using ByteSizeLib;
 
 namespace GodelTech.CodeReview.Orchestrator.Services
 {
     public interface IDirectoryService
     {
+        ByteSize DirectorySize(string path);
         bool Exists(string path);
         DirectoryInfo CreateDirectory(string path);
         void Delete(string path, bool recursive);

--- a/src/CodeReview.Orchestrator/Services/IFileService.cs
+++ b/src/CodeReview.Orchestrator/Services/IFileService.cs
@@ -1,9 +1,13 @@
-﻿using System.Threading.Tasks;
+﻿using System.IO;
+using System.Threading.Tasks;
 
 namespace GodelTech.CodeReview.Orchestrator.Services
 {
     public interface IFileService
     {
+        void Delete(string path);
+        Stream Open(string path);
+        void Move(string sourceFileName, string destFileName);
         Task<string> ReadAllTextAsync(string path);
         Task WriteAllTextAsync(string path, string text);
         bool Exists(string path);

--- a/src/CodeReview.Orchestrator/Services/IPathService.cs
+++ b/src/CodeReview.Orchestrator/Services/IPathService.cs
@@ -4,7 +4,9 @@
     {
         string GetDirectoryName(string path);
         string GetFullPath(string path);
+        string GetTempFileName();
         string Combine(params string[] parts);
+        string ChangeExtensions(string path, string ext);
         bool IsPathRooted(string path);
         string GetTempPath();
     }

--- a/src/CodeReview.Orchestrator/Services/ITarArchiveService.cs
+++ b/src/CodeReview.Orchestrator/Services/ITarArchiveService.cs
@@ -4,7 +4,8 @@ namespace GodelTech.CodeReview.Orchestrator.Services
 {
     public interface ITarArchiveService
     {
-        Stream Create(string path);
+        Stream CreateInMemory(string path);
+        Stream CreateInFile(string path, string tmpFilePath);
         void Extract(Stream inStream, string folderPath, string pathToRemove);
     }
 }

--- a/src/CodeReview.Orchestrator/Services/ITempFileFactory.cs
+++ b/src/CodeReview.Orchestrator/Services/ITempFileFactory.cs
@@ -1,0 +1,8 @@
+namespace GodelTech.CodeReview.Orchestrator.Services
+{
+    public interface ITempFileFactory
+    {
+        TempFile Create();
+        TempFile Create(string ext);
+    }
+}

--- a/src/CodeReview.Orchestrator/Services/PathService.cs
+++ b/src/CodeReview.Orchestrator/Services/PathService.cs
@@ -14,6 +14,11 @@ namespace GodelTech.CodeReview.Orchestrator.Services
             return Path.GetTempPath();
         }
 
+        public string GetTempFileName()
+        {
+            return Path.GetTempFileName();
+        }
+
         public string GetDirectoryName(string path)
         {
             return Path.GetDirectoryName(path);
@@ -27,6 +32,11 @@ namespace GodelTech.CodeReview.Orchestrator.Services
         public string Combine(params string[] parts)
         {
             return Path.Combine(parts);
+        }
+
+        public string ChangeExtensions(string path, string ext)
+        {
+            return Path.ChangeExtension(path, ext);
         }
     }
 }

--- a/src/CodeReview.Orchestrator/Services/TarArchiveService.cs
+++ b/src/CodeReview.Orchestrator/Services/TarArchiveService.cs
@@ -8,61 +8,85 @@ namespace GodelTech.CodeReview.Orchestrator.Services
 {
     public class TarArchiveService : ITarArchiveService
     {
+        private readonly IFileService _fileService;
         private readonly IDirectoryService _directoryService;
         private readonly IOutputFolderPathCalculator _outputFolderPathCalculator;
 
         public TarArchiveService(
+            IFileService fileService,
             IDirectoryService directoryService,
             IOutputFolderPathCalculator outputFolderPathCalculator)
         {
+            _fileService = fileService ?? throw new ArgumentNullException(nameof(fileService));
             _directoryService = directoryService ?? throw new ArgumentNullException(nameof(directoryService));
             _outputFolderPathCalculator = outputFolderPathCalculator ?? throw new ArgumentNullException(nameof(outputFolderPathCalculator));
         }
-        
-        public Stream Create(string path)
+
+        public Stream CreateInMemory(string path)
         {
             if (string.IsNullOrWhiteSpace(path))
                 throw new ArgumentException("Value cannot be null or whitespace.", nameof(path));
-            
+
             var outStream = new MemoryStream();
 
             using (var writer = WriterFactory.Open(outStream, ArchiveType.Tar, CompressionType.None))
             {
                 writer.WriteAll(path, "*", SearchOption.AllDirectories);
             }
-            
+
             outStream.Position = 0;
 
             return outStream;
         }
 
+        public Stream CreateInFile(string path, string tmpFilePath)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+                throw new ArgumentException("Value cannot be null or whitespace.", nameof(path));
+
+            if (string.IsNullOrWhiteSpace(tmpFilePath))
+                throw new ArgumentException("Value cannot be null or whitespace.", nameof(tmpFilePath));
+
+            var stream = _fileService.Open(tmpFilePath);
+
+            using (var writer = WriterFactory.Open(stream, ArchiveType.Tar, CompressionType.None))
+            {
+                writer.WriteAll(path, "*", SearchOption.AllDirectories);
+            }
+
+            stream.Seek(0, SeekOrigin.Begin);
+
+            return stream;
+        }
+
         public void Extract(Stream inStream, string folderPath, string pathToRemove)
         {
-            if (inStream == null) 
+            if (inStream == null)
                 throw new ArgumentNullException(nameof(inStream));
-            if (folderPath == null) 
+
+            if (folderPath == null)
                 throw new ArgumentNullException(nameof(folderPath));
 
             pathToRemove ??= string.Empty;
 
             var reader = ReaderFactory.Open(inStream);
-            
+
             while (reader.MoveToNextEntry())
             {
-                if (reader.Entry.IsDirectory) 
+                if (reader.Entry.IsDirectory)
                     continue;
 
                 var outputDirectory = _outputFolderPathCalculator.CalculateOutputDirectoryName(
                     folderPath,
                     pathToRemove,
                     reader.Entry.Key);
-                
+
                 if (!_directoryService.Exists(outputDirectory))
                     _directoryService.CreateDirectory(outputDirectory);
-                
+
                 reader.WriteEntryToDirectory(outputDirectory, new ExtractionOptions
                 {
-                    ExtractFullPath = false, 
+                    ExtractFullPath = false,
                     Overwrite = true
                 });
             }

--- a/src/CodeReview.Orchestrator/Services/TempFile.cs
+++ b/src/CodeReview.Orchestrator/Services/TempFile.cs
@@ -1,20 +1,20 @@
-﻿using System;
+using System;
 
 namespace GodelTech.CodeReview.Orchestrator.Services
 {
-    public class TempFolder : IDisposable
+    public class TempFile : IDisposable
     {
         private readonly Action _cleanUpAction;
 
         public string Path { get; }
 
-        public TempFolder(string tempFolderPath, Action cleanUpAction)
+        public TempFile(string path, Action cleanUpAction)
         {
             _cleanUpAction = cleanUpAction ?? throw new ArgumentNullException(nameof(cleanUpAction));
-            Path = tempFolderPath ?? throw new ArgumentNullException(nameof(tempFolderPath));
+            Path = path ?? throw new ArgumentNullException(nameof(path));
         }
 
-        void IDisposable.Dispose()
+        public void Dispose()
         {
             _cleanUpAction();
         }

--- a/src/CodeReview.Orchestrator/Services/TempFileFactory.cs
+++ b/src/CodeReview.Orchestrator/Services/TempFileFactory.cs
@@ -1,0 +1,42 @@
+using System;
+
+namespace GodelTech.CodeReview.Orchestrator.Services
+{
+    public class TempFileFactory : ITempFileFactory
+    {
+        private readonly IPathService _pathService;
+        private readonly IFileService _fileService;
+
+        public TempFileFactory(IPathService pathService, IFileService fileService)
+        {
+            _pathService = pathService ?? throw new ArgumentNullException(nameof(pathService));
+            _fileService = fileService ?? throw new ArgumentNullException(nameof(fileService));
+        }
+
+        public TempFile Create()
+        {
+            var tmpFile = _pathService.GetTempFileName();
+
+            return CreateInternal(tmpFile);
+        }
+
+        public TempFile Create(string ext)
+        {
+            var oldPath = _pathService.GetTempFileName();
+            var newPath = _pathService.ChangeExtensions(oldPath, ext);
+
+            _fileService.Move(oldPath, newPath);
+
+            return CreateInternal(newPath);
+        }
+
+        private TempFile CreateInternal(string path)
+        {
+            return new TempFile(path, () =>
+            {
+                if (_fileService.Exists(path))
+                    _fileService.Delete(path);
+            });
+        }
+    }
+}

--- a/src/CodeReview.Orchestrator/Utils/ByteSize.cs
+++ b/src/CodeReview.Orchestrator/Utils/ByteSize.cs
@@ -1,0 +1,53 @@
+﻿using System;
+
+namespace GodelTech.CodeReview.Orchestrator.Utils
+{
+    public readonly struct ByteSize
+    {
+        public ByteSize(long bits)
+        {
+            Bits = bits;
+            Bytes = bits / 8.0;
+            Kilobyte = Bytes / 1024.0;
+            Megabyte = Kilobyte / 1024.0;
+        }
+
+        public long Bits { get; }
+        public double Bytes { get; }
+        public double Kilobyte { get; }
+        public double Megabyte { get; }
+
+        public static bool operator ==(ByteSize b1, ByteSize b2)
+            => b1.Bits == b2.Bits;
+
+        public static bool operator !=(ByteSize b1, ByteSize b2)
+            => b1.Bits != b2.Bits;
+
+        public static bool operator >(ByteSize b1, ByteSize b2)
+            => b1.Bits > b2.Bits;
+
+        public static bool operator >=(ByteSize b1, ByteSize b2)
+            => b1.Bits <= b2.Bits;
+
+        public static bool operator <(ByteSize b1, ByteSize b2)
+            => b1.Bits < b2.Bits;
+
+        public static bool operator <=(ByteSize b1, ByteSize b2)
+            => b1.Bits <= b2.Bits;
+
+        public bool Equals(ByteSize other)
+            => Bits == other.Bits;
+
+        public override bool Equals(object obj)
+            => obj is ByteSize other && Equals(other);
+
+        public override int GetHashCode()
+            => HashCode.Combine(Bits);
+
+        public static ByteSize FromBytes(double bytes) 
+            => new((long)bytes * 8);
+
+        public static ByteSize FromMegabytes(double megabytes) 
+            => new((long)(megabytes * 1024 * 1024 * 8));
+    }
+}

--- a/src/CodeReview.Orchestrator/Utils/Disposable.cs
+++ b/src/CodeReview.Orchestrator/Utils/Disposable.cs
@@ -6,10 +6,65 @@ namespace GodelTech.CodeReview.Orchestrator.Utils
     public static class Disposable
     {
         public static readonly IAsyncDisposable AsyncEmpty = new AsyncDisposable();
+
+        public static IDisposable CreateDisposableAction(Action action)
+            => new DisposableAction(action);
         
+        public static IDisposable CreateDisposableAction<T>(T value, Action<T> action)
+            => new DisposableAction<T>(action, value);
+
         private class AsyncDisposable : IAsyncDisposable
         {
             public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+        }
+
+        private sealed class DisposableAction : IDisposable
+        {
+            private readonly Action _action;
+
+            public DisposableAction(Action action)
+            {
+                _action = action ?? throw new ArgumentNullException(nameof(action));
+            }
+
+            public void Dispose()
+            {
+                Dispose(true);
+            }
+
+            private void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    _action();
+                }
+            }
+        }
+
+        public sealed class DisposableAction<T> : IDisposable
+        {
+            private readonly Action<T> _action;
+
+            public DisposableAction(Action<T> action, T val)
+            {
+                _action = action ?? throw new ArgumentNullException(nameof(action));
+                Value = val;
+            }
+
+            public T Value { get; }
+
+            public void Dispose()
+            {
+                Dispose(true);
+            }
+
+            private void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    _action(Value);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
#### CHANGE TYPE
<!--- MANDATORY: Delete the items that don't apply -->
 - [ ] Major
 - [ ] Minor
 - [x] Patch

#### GITHUB ISSUE LINK


#### IMPACT, DEPENDENCIES AND TEST CONSIDERATIONS
If `folderToImport` is larger than 300 MB, Orchestrator will create a tmp file (instead of using memory) to import the folder to the container. After the import completes Orchestrator will delete the tmp file